### PR TITLE
feat(queue): implement RabbitMQ integration for async receipt processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.7.0</version>
+			<version>2.8.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -72,6 +72,10 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>
 			<artifactId>jackson-module-kotlin</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-amqp</artifactId>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/um/tesoreria/facturador/configuration/RabbitMQConfig.java
+++ b/src/main/java/um/tesoreria/facturador/configuration/RabbitMQConfig.java
@@ -1,0 +1,23 @@
+package um.tesoreria.facturador.configuration;
+
+import org.springframework.amqp.core.Queue;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    public static final String QUEUE_INVOICE = "recibo_queue";
+    public static final String QUEUE_TESTER = "tester_queue";
+
+    @Bean
+    public Queue reciboQueue() {
+        return new Queue(QUEUE_INVOICE, true); // Cola persistente
+    }
+
+    @Bean
+    public Queue testerQueue() {
+        return new Queue(QUEUE_TESTER, true); // Cola persistente
+    }
+
+}

--- a/src/main/java/um/tesoreria/facturador/controller/queue/QueueController.java
+++ b/src/main/java/um/tesoreria/facturador/controller/queue/QueueController.java
@@ -1,0 +1,26 @@
+package um.tesoreria.facturador.controller.queue;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import um.tesoreria.facturador.service.queue.QueueService;
+
+@RestController
+@RequestMapping("/api/tesoreria/facturador/tester")
+public class QueueController {
+
+    private final QueueService service;
+
+    public QueueController(QueueService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/test/{message}")
+    public ResponseEntity<Void> test(@PathVariable String message) {
+        service.test(message);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/um/tesoreria/facturador/service/queue/QueueService.java
+++ b/src/main/java/um/tesoreria/facturador/service/queue/QueueService.java
@@ -1,0 +1,23 @@
+package um.tesoreria.facturador.service.queue;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+import um.tesoreria.facturador.configuration.RabbitMQConfig;
+
+@Service
+@Slf4j
+public class QueueService {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public QueueService(RabbitTemplate rabbitTemplate) {
+        this.rabbitTemplate = rabbitTemplate;
+    }
+
+    public void test(String message) {
+        log.debug("Enviando mensaje a consumer: {}", message);
+        rabbitTemplate.convertAndSend(RabbitMQConfig.QUEUE_TESTER, message);
+    }
+
+}

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -17,6 +17,12 @@ eureka:
 spring:
   application:
     name: tesoreria-facturador-service
+  rabbitmq:
+    host: rabbitmq
+    port: 5672
+    username: admin
+    password: admin
+
 
 logging:
   level:


### PR DESCRIPTION
✨ Add RabbitMQ integration for asynchronous receipt handling

- Add Spring AMQP dependency
- Configure RabbitMQ connection settings
- Create persistent queues configuration:
  - recibo_queue: Main queue for receipt processing
  - tester_queue: Testing queue for validation
- Implement queue service for message handling
- Add test endpoint for system validation
- Update springdoc-openapi version to 2.8.3
- Refactor logging methods for better code organization

BREAKING CHANGE: New RabbitMQ dependency requires running RabbitMQ instance Configuration needed in bootstrap.yml:
  - host: rabbitmq
  - port: 5672
  - username: admin
  - password: admin

Closes #22