### PR TITLE
feat(rabbitmq): implementar JSON message converter y endpoint de prueba

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,25 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<version>9.0.0.CR1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>3.1.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+			<version>3.2.0</version>
+		</dependency>
 	</dependencies>
+
 	<dependencyManagement>
 		<dependencies>
 			<dependency>

--- a/src/main/java/um/tesoreria/facturador/configuration/RabbitMQConfig.java
+++ b/src/main/java/um/tesoreria/facturador/configuration/RabbitMQConfig.java
@@ -1,6 +1,8 @@
 package um.tesoreria.facturador.configuration;
 
 import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -18,6 +20,11 @@ public class RabbitMQConfig {
     @Bean
     public Queue testerQueue() {
         return new Queue(QUEUE_TESTER, true); // Cola persistente
+    }
+
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
     }
 
 }

--- a/src/main/java/um/tesoreria/facturador/controller/FacturadorController.java
+++ b/src/main/java/um/tesoreria/facturador/controller/FacturadorController.java
@@ -38,4 +38,10 @@ public class FacturadorController {
         return new ResponseEntity<>(service.facturaOne(chequeraPagoId), HttpStatus.OK);
     }
 
+    @GetMapping("/testInvoiceQueue/{facturaElectronicaId}")
+    public ResponseEntity<Void> testInvoiceQueue(@PathVariable Long facturaElectronicaId) {
+        service.testInvoiceQueue(facturaElectronicaId);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/um/tesoreria/facturador/service/FacturadorService.java
+++ b/src/main/java/um/tesoreria/facturador/service/FacturadorService.java
@@ -190,6 +190,13 @@ public class FacturadorService {
         rabbitTemplate.convertAndSend(RabbitMQConfig.QUEUE_INVOICE, facturacionElectronica);
     }
 
+    public void testInvoiceQueue(Long facturaElectronicaId) {
+        log.debug("Processing testInvoiceQueue");
+        var facturacionElectronica = facturacionElectronicaClient.findByFacturacionElectronicaId(facturaElectronicaId);
+        logFacturacionElectronica(facturacionElectronica);
+        sendReciboQueue(facturacionElectronica);
+    }
+
     private void logFacturacion(String apellido, String nombre, FacturacionDto facturacion) {
         try {
             log.info("Facturacion {} {}: {}", apellido, nombre, JsonMapper.builder().findAndAddModules().build().writerWithDefaultPrettyPrinter().writeValueAsString(facturacion));


### PR DESCRIPTION
# Descripción
Implementa la configuración de RabbitMQ para soportar serialización JSON y agrega un endpoint de prueba para el envío de recibos electrónicos.

# Cambios Realizados
- ✨ Agrega Jackson2JsonMessageConverter para serialización JSON en RabbitMQ
- 🔧 Configura colas persistentes recibo_queue y tester_queue
- ✨ Implementa nuevo endpoint GET /testInvoiceQueue/{facturaElectronicaId}
- 📦 Agrega dependencias necesarias:
  - Hibernate Validator
  - Jakarta Validation API
  - Caffeine Cache

# Testing
- ✅ Verificada serialización JSON de mensajes
- ✅ Probado endpoint con diferentes IDs
- ✅ Validada persistencia de mensajes en cola

# Breaking Changes
N/A

# Dependencias
- spring-amqp
- jackson-databind
- hibernate-validator
- jakarta.validation-api
- caffeine

Closes #24