### PR TITLE
feat(queue): enhance RabbitMQ with transactions and retry policies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,12 @@
 			<artifactId>caffeine</artifactId>
 		</dependency>
 
+		<!-- Spring Transaction -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-tx</artifactId>
+		</dependency>
+
 	</dependencies>
 
 	<dependencyManagement>

--- a/src/main/java/um/tesoreria/facturador/configuration/RabbitMQConfig.java
+++ b/src/main/java/um/tesoreria/facturador/configuration/RabbitMQConfig.java
@@ -1,10 +1,17 @@
 package um.tesoreria.facturador.configuration;
 
 import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.transaction.RabbitTransactionManager;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
 
 @Configuration
 public class RabbitMQConfig {
@@ -25,6 +32,46 @@ public class RabbitMQConfig {
     @Bean
     public MessageConverter jsonMessageConverter() {
         return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate template = new RabbitTemplate(connectionFactory);
+        template.setMessageConverter(jsonMessageConverter());
+        
+        // Configurar política de reintentos
+        RetryTemplate retryTemplate = new RetryTemplate();
+        
+        ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
+        backOffPolicy.setInitialInterval(500);    // 500ms inicial
+        backOffPolicy.setMultiplier(2.0);         // duplicar tiempo entre reintentos
+        backOffPolicy.setMaxInterval(10000);      // máximo 10 segundos
+        
+        SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy();
+        retryPolicy.setMaxAttempts(3);            // máximo 3 intentos
+        
+        retryTemplate.setBackOffPolicy(backOffPolicy);
+        retryTemplate.setRetryPolicy(retryPolicy);
+        
+        template.setRetryTemplate(retryTemplate);
+        return template;
+    }
+
+    @Bean
+    public RabbitTransactionManager rabbitTransactionManager(ConnectionFactory connectionFactory) {
+        return new RabbitTransactionManager(connectionFactory);
+    }
+
+    @Bean
+    public ConnectionFactory connectionFactory() {
+        CachingConnectionFactory factory = new CachingConnectionFactory();
+        // Limitar el número de canales por conexión
+        factory.setChannelCacheSize(5);           // Suficiente para un servicio de facturación
+        // Limitar el número de conexiones en caché
+        factory.setCacheMode(CachingConnectionFactory.CacheMode.CHANNEL);
+        // Establecer límite de tiempo para conexiones inactivas
+        factory.setChannelCheckoutTimeout(1000);  // 1 segundo es adecuado para el caso de uso
+        return factory;
     }
 
 }

--- a/src/main/java/um/tesoreria/facturador/service/queue/ReciboQueueService.java
+++ b/src/main/java/um/tesoreria/facturador/service/queue/ReciboQueueService.java
@@ -1,0 +1,27 @@
+package um.tesoreria.facturador.service.queue;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import um.tesoreria.facturador.configuration.RabbitMQConfig;
+import um.tesoreria.facturador.kotlin.tesoreria.core.dto.FacturacionElectronicaDto;
+
+@Service
+@Slf4j
+public class ReciboQueueService {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public ReciboQueueService(RabbitTemplate rabbitTemplate) {
+        this.rabbitTemplate = rabbitTemplate;
+    }
+
+    @Transactional
+    public void sendReciboQueue(FacturacionElectronicaDto facturacionElectronica) {
+        log.debug("Processing FacturadorService.sendReciboQueue");
+        log.debug("Encolando envío");
+        rabbitTemplate.convertAndSend(RabbitMQConfig.QUEUE_INVOICE, facturacionElectronica);
+    }
+
+}


### PR DESCRIPTION
🔄 Improve queue management and reliability

- Add transaction management:
  - Implement RabbitTransactionManager
  - Add spring-tx dependency
  - Create dedicated ReciboQueueService

- Configure retry policies:
  - Exponential backoff: 500ms → 10s
  - Max 3 attempts
  - Channel timeout: 1s

- Optimize connection settings:
  - Channel cache size: 5
  - Channel cache mode
  - Connection timeouts

- Refactor FacturadorService:
  - Move queue logic to ReciboQueueService
  - Add transactional support
  - Clean up dependencies

No breaking changes.

Closes #32