### PR TITLE
docs: update endpoints documentation and service status

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,14 @@ Microservicio de facturación electrónica para UM Tesorería. Se encarga de:
 - `GET /facturador/facturaPendientes`: Procesa facturas pendientes
 - `GET /facturador/facturaOne/{chequeraPagoId}`: Procesa una factura específica
 - `GET /facturador/sendPendientes`: Envía recibos pendientes
-- `GET /facturador/sendOneByChequeraPagoId/{chequeraPagoId}`: Envía recibo por ID de chequera
-- `GET /facturador/sendOneByFacturacionElectronicaId/{facturacionElectronicaId}`: Envía recibo por ID de factura
+- `GET /facturador/sendOne/pago/{chequeraPagoId}`: Envía recibo por ID de chequera
+- `GET /facturador/sendOne/factura/{facturacionElectronicaId}`: Envía recibo por ID de factura
 - `GET /facturador/testInvoiceQueue/{facturaElectronicaId}`: Prueba el envío de recibos
 - `GET /facturador/testManyInvoiceQueue`: Prueba el envío de múltiples recibos
+
+### Notas
+- El envío automático de recibos pendientes está temporalmente desactivado
+- Los endpoints de prueba son solo para desarrollo
 
 ## 🛠️ Desarrollo
 

--- a/src/main/java/um/tesoreria/facturador/controller/FacturadorController.java
+++ b/src/main/java/um/tesoreria/facturador/controller/FacturadorController.java
@@ -34,11 +34,11 @@ public class FacturadorController {
         return new ResponseEntity<>(service.facturaOne(chequeraPagoId), HttpStatus.OK);
     }
 
-    @Scheduled(cron = "0 0 * * * *")
-    public ResponseEntity<Void> sendPendientesScheduled() {
-        service.sendPendientes();
-        return ResponseEntity.ok().build();
-    }
+//    @Scheduled(cron = "0 0 * * * *")
+//    public ResponseEntity<Void> sendPendientesScheduled() {
+//        service.sendPendientes();
+//        return ResponseEntity.ok().build();
+//    }
 
     @GetMapping("/sendOne/pago/{chequeraPagoId}")
     public ResponseEntity<String> sendOneByChequeraPagoId(@PathVariable Long chequeraPagoId) {


### PR DESCRIPTION
🔄 Improve documentation accuracy and service state

- Update endpoint URLs in README:
  - /sendOneByChequeraPagoId → /sendOne/pago
  - /sendOneByFacturacionElectronicaId → /sendOne/factura

- Add service status notes:
  - Document automatic sending temporary disable
  - Clarify test endpoints purpose

- Disable scheduled task:
  - Comment out sendPendientesScheduled
  - Keep code for future reactivation

No breaking changes.

Closes #42